### PR TITLE
🐛 Fixes issue #1 Docs folder commented on config.js

### DIFF
--- a/templates/config.js
+++ b/templates/config.js
@@ -16,9 +16,9 @@ module.exports = {
     swaggerDefinition: {
       info: {
         title: 'Adonis 💘 Swagger',
-        version: '1.0.0',
+        version: '1.0.0'
       },
-  
+
       basePath: '/',
 
       // Example security definitions.
@@ -40,17 +40,15 @@ module.exports = {
             write: 'Grants write access (this is just sample)',
             admin: 'Grants read and write access to administrative information (this is just sample)'
           }
-        },
+        }
       }
     },
 
     // Path to the API docs
     // Sample usage
-    // apis: [
-    //    'docs/**/*.yml',    // load recursive all .yml file in docs directory
-    //    'docs/**/*.js',     // load recursive all .js file in docs directory
-    // ]
     apis: [
+      'docs/**/*.yml', // load recursive all .yml file in docs directory
+      'docs/**/*.js', // load recursive all .js file in docs directory
       'app/**/*.js',
       'start/routes.js'
     ]


### PR DESCRIPTION
- Problem: Docs folder wasn't being loaded on `adonis swagger:export` command
because this folder was commented on config.js file

- Solution: Just added the commented lines inside to `apis` array on
`config.js` file